### PR TITLE
Updated Device subclass for SoapySDR 0.8, use parallel device (un)make

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,12 @@
 ########################################################################
- # Build Soapy SDR support module for HackRF
- ########################################################################
-
-cmake_minimum_required(VERSION 2.8.7)
+# Build Multi Soapy SDR support module
+########################################################################
+cmake_minimum_required(VERSION 3.1.0)
 project(SoapyMultiSDR CXX)
 
-find_package(SoapySDR "0.4.0" NO_MODULE)
+set(CMAKE_CXX_STANDARD 11)
+
+find_package(SoapySDR 0.8 CONFIG)
 if (NOT SoapySDR_FOUND)
     message(FATAL_ERROR "Soapy SDR development files not found...")
 endif ()

--- a/SoapyMultiSDR.hpp
+++ b/SoapyMultiSDR.hpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2016-2017 Josh Blum
+//               2021-2022 Nicholas Corgan
 // SPDX-License-Identifier: BSL-1.0
 
 #pragma once
@@ -156,6 +157,12 @@ public:
 
     std::complex<double> getIQBalance(const int direction, const size_t channel) const;
 
+    bool hasIQBalanceMode(const int direction, const size_t channel) const;
+
+    void setIQBalanceMode(const int direction, const size_t channel, const bool automatic);
+
+    bool getIQBalanceMode(const int direction, const size_t channel) const;
+
     bool hasFrequencyCorrection(const int direction, const size_t channel) const;
 
     void setFrequencyCorrection(const int direction, const size_t channel, const double value);
@@ -240,6 +247,12 @@ public:
 
     SoapySDR::RangeList getMasterClockRates(void) const;
 
+    void setReferenceClockRate(const double rate);
+
+    double getReferenceClockRate(void) const;
+
+    SoapySDR::RangeList getReferenceClockRates(void) const;
+
     std::vector<std::string> listClockSources(void) const;
 
     void setClockSource(const std::string &source);
@@ -294,17 +307,25 @@ public:
 
     unsigned readRegister(const unsigned addr) const;
 
+    void writeRegisters(const std::string &name, const unsigned addr, const std::vector<unsigned> &value);
+
+    std::vector<unsigned> readRegisters(const std::string &name, const unsigned addr, const size_t length) const;
+
     /*******************************************************************
      * Settings API
      ******************************************************************/
 
     SoapySDR::ArgInfoList getSettingInfo(void) const;
 
+    SoapySDR::ArgInfo getSettingInfo(const std::string &key) const;
+
     void writeSetting(const std::string &key, const std::string &value);
 
     std::string readSetting(const std::string &key) const;
 
     SoapySDR::ArgInfoList getSettingInfo(const int direction, const size_t channel) const;
+
+    SoapySDR::ArgInfo getSettingInfo(const int direction, const size_t channel, const std::string &key) const;
 
     void writeSetting(const int direction, const size_t channel, const std::string &key, const std::string &value);
 


### PR DESCRIPTION
* Bumped minimum required SoapySDR version to 0.8